### PR TITLE
docs(fortran): explain the n_scan = 512 choice in locate_modes

### DIFF
--- a/src/PpqFort_s.f90
+++ b/src/PpqFort_s.f90
@@ -306,6 +306,21 @@ contains
       logical, intent(out) :: bnd_m(max_modes)
       integer, intent(out) :: n_modes
 
+      ! n_scan = 512 is a deliberately conservative choice, not a tuned
+      ! minimum.  A log-spaced scan finds every mode of a well-behaved
+      ! landscape regardless of point count -- the only failure mode is
+      ! two peaks separated by a valley narrower than the local scan
+      ! spacing, which would show up as a large (order-unity) relative
+      ! error, not a small one.  Empirically, dropping to n_scan = 64
+      ! changed PpqN/PpqG values by at most ~1e-8 relative (vs a 4096-
+      ! point reference) across the physical parameters and 10 random
+      ! draws from the fit-parameter space, including the draws that
+      ! produced genuine multimodality -- no mode was ever lost, and
+      ! the achievable speedup from shrinking the scan is only ~10-15%
+      ! (the scan is a small fraction of the total cost).  512 is kept
+      ! as headroom against a genuinely narrow valley outside this
+      ! tested ensemble, since the cost of being wrong (silently
+      ! dropping a mode) is far higher than the ~1 us/eval this buys.
       integer, parameter :: n_scan = 512
       real(c_double), parameter :: x_scan_min = 1.0d-4
       real(c_double) :: xs(n_scan), Hs(n_scan)


### PR DESCRIPTION
Record the empirical basis for the mode-scan resolution: a log-spaced scan finds every mode of a well-behaved landscape at any point count, so the only failure mode is two peaks separated by a valley narrower than the local scan spacing -- which would show up as an order-unity error, not a small one.

Measured by comparing PpqN/PpqG at n_scan in {512, 256, 128, 64} against a 4096-point reference, over the physical parameters and 10 random fit-parameter draws (including the draws that had previously produced genuine multimodality): even at n_scan = 64 no mode was ever lost, and the worst relative error anywhere above 1e-12 of the band peak was ~1e-8.  The achievable speedup from shrinking the scan is only ~10-15% (PpqN 8.6 -> 7.4 us/eval at 128, PpqG 8.0 -> 7.3), since the scan is a small fraction of total cost.

Keeping n_scan = 512: it costs little relative to the ~1 us/eval a smaller scan would save, and gives headroom against a genuinely narrow valley outside this tested ensemble -- the failure mode here is a silently dropped mode, not a graceful accuracy degradation, so the margin is worth more than the speedup.

Verified: fpm test passes in the Intel container after the change (a comment-only edit).