### PR TITLE
feat(test): add single-bin integration diagnostics

### DIFF
--- a/test/python/README.md
+++ b/test/python/README.md
@@ -27,11 +27,12 @@ detector response — so agreement means the PDFs describe the physics.
 
 | Module | Role |
 |--------|------|
-| `chisquare_harness.py` | PDF-agnostic machinery: equibin binning, expected counts by per-bin quadrature, batched chi-square throws.  Every band PDF here is a narrow ridge, so the per-bin quadrature requires an `inner_points_func` (breakpoints). |
+| `chisquare_harness.py` | PDF-agnostic machinery: equibin binning, expected counts by per-bin quadrature, batched chi-square throws, and a `debug_bin` helper for inspecting one bin's integration in isolation.  Every band PDF here is a narrow ridge, so the per-bin quadrature requires an `inner_points_func` (breakpoints). |
 | `band_breakpoints.py` | Band physics for the per-bin quadrature: where the band ridge is and how wide it is, packaged as breakpoints for the harness. |
 | `generate_events.py` | The independent physics simulator (truth generator) for the two simulator tests. |
 | `sample_from_pdf.py` | Grid-based sampling from an arbitrary PDF (lintsampler), used by the self-consistency tests. |
 | `quad_breakpoints_demo.py` | Self-contained demonstration (no repo dependencies) of why adaptive quadrature silently misses narrow peaks and how `points=` fixes it. |
+| `debug_bin_example.py` | Example driver for `chisquare_harness.debug_bin`: point it at one (Ep, Eq) bin and a parameter set to see why that bin's expected count looks the way it does. |
 
 ## Integrating the PDF over bins
 
@@ -52,3 +53,35 @@ Suggested reading order:
 3. `chisquare_harness.py`, `expected_counts_from_pdf` — the nested
    quadrature that requires those breakpoints (`inner_points_func`) and
    normalizes the per-bin integrals into expected counts.
+
+## Debugging a single bin
+
+When a bin's expected count comes out at 0 or suspiciously small, it isn't
+automatically a quadrature bug: a wide tail bin can genuinely sit mostly (or
+entirely) off the band, in which case a tiny expected count is the correct
+answer. `chisquare_harness.debug_bin(pdf_func, bin_rect, inner_points_func)`
+tells the two cases apart by computing the same bin three independent ways:
+
+- **naive** — nested quad with no breakpoints (what you'd get without
+  `inner_points_func`; reproduces the missed-peak failure mode).
+- **fixed** — nested quad with `inner_points_func`, exactly as
+  `expected_counts_from_pdf` computes it.
+- **grid_ref** — a brute-force fixed-grid Simpson integral, independent of
+  quad's adaptive logic entirely.
+
+It also prints where `inner_points_func`'s breakpoints land relative to the
+bin at a few Ep values, flagging when all of them fall outside `[ymin,
+ymax]` — a sign the ridge has drifted off the bin's Eq range there rather
+than quad having missed anything.
+
+If all three numbers agree, the small value is real (the bin is genuinely
+mostly off the ridge). If `naive` disagrees with `fixed`/`grid_ref`, that's
+the silent-miss failure from the "Integrating the PDF over bins" section
+above, on this specific bin.
+
+`debug_bin_example.py` is a ready-to-edit driver: set `BIN` and the
+parameter dict to the case you're chasing and run
+
+```
+LD_LIBRARY_PATH=lib python test/python/debug_bin_example.py
+```

--- a/test/python/chisquare_harness.py
+++ b/test/python/chisquare_harness.py
@@ -30,7 +30,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import equibin
-from scipy.integrate import quad
+from scipy.integrate import quad, simpson
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +101,116 @@ def expected_counts_from_pdf(pdf_func, bins, n_events, inner_points_func, *,
         raise ValueError("PDF integrates to zero over all bins.")
 
     return n_events * integrals / total
+
+
+# ---------------------------------------------------------------------------
+# Single-bin diagnostics
+# ---------------------------------------------------------------------------
+
+def debug_bin(pdf_func, bin_rect, inner_points_func, *,
+              n_ep_probe=5, n_grid=400):
+    """
+    Diagnose the nested-quadrature integral of pdf_func over one bin.
+
+    Use this when expected_counts_from_pdf reports a ~0 integral for a
+    bin and it's unclear whether that's *physically correct* (the PDF
+    really is negligible there) or a quadrature failure (quad missed
+    the ridge).  It prints, and returns, three independent estimates:
+
+    - naive: nested quad with no breakpoints at all (what you'd get
+      without inner_points_func -- reproduces the failure mode).
+    - fixed: nested quad with inner_points_func, exactly as
+      expected_counts_from_pdf computes it.
+    - grid_ref: a brute-force fixed grid (Simpson's rule in both
+      directions).  This can't miss a feature the grid resolves,
+      independently of quad's adaptive logic entirely, so a disagreement
+      between grid_ref and fixed is a red flag even when breakpoints are
+      in play (e.g. the breakpoint window is too narrow, or the ridge
+      formula doesn't match the PDF being tested).
+
+    It also prints the raw breakpoints inner_points_func returns at a
+    few Ep values spanning the bin, and which of those survive the
+    (ymin, ymax) clip -- if every point is being filtered out, the
+    ridge has drifted entirely outside the bin's Eq range at that Ep,
+    which is the first thing to check for a bin sitting at the edge of
+    the band.
+
+    Parameters
+    ----------
+    pdf_func : callable
+        pdf_func(Ep_flat, Eq_flat) -> values_flat
+    bin_rect : (xmin, xmax, ymin, ymax)
+        The single bin to integrate.
+    inner_points_func : callable or None
+        Same as expected_counts_from_pdf's inner_points_func.  Pass
+        None to see only the naive and grid_ref estimates.
+    n_ep_probe : int
+        Number of Ep values, evenly spaced across the bin, to print
+        breakpoints for.
+    n_grid : int
+        Grid resolution (n_grid x n_grid) for the brute-force reference.
+        Must be fine enough to resolve the narrowest feature of the PDF
+        inside the bin -- if grid_ref itself looks suspicious (e.g. 0
+        when fixed is not), raise this before trusting either estimate.
+
+    Returns
+    -------
+    dict with keys: naive, naive_err, fixed, fixed_err, grid_ref,
+    breakpoints (list of (ep, raw_points, kept_points)).
+    """
+    xmin, xmax, ymin, ymax = bin_rect
+    print(f"bin: Ep in [{xmin}, {xmax}], Eq in [{ymin}, {ymax}]")
+
+    def integrand(eq, ep):
+        return float(pdf_func(np.array([ep]), np.array([eq]))[0])
+
+    def inner(ep, points_func):
+        pts = None
+        if points_func is not None:
+            pts = [p for p in points_func(ep, ymin, ymax) if ymin < p < ymax]
+            pts = sorted(pts) or None
+        return quad(integrand, ymin, ymax, args=(ep,), points=pts, limit=200)
+
+    naive, naive_err = quad(lambda ep: inner(ep, None)[0], xmin, xmax, limit=200)
+    print(f"naive nested quad (no breakpoints) = {naive:.6g}  "
+          f"(outer err est {naive_err:.2g})")
+
+    fixed = fixed_err = None
+    breakpoints_probed = []
+    if inner_points_func is not None:
+        fixed, fixed_err = quad(lambda ep: inner(ep, inner_points_func)[0],
+                                xmin, xmax, limit=200)
+        print(f"nested quad with breakpoints       = {fixed:.6g}  "
+              f"(outer err est {fixed_err:.2g})")
+
+        print(f"\nbreakpoints probed at {n_ep_probe} Ep values across the bin:")
+        for ep in np.linspace(xmin, xmax, n_ep_probe):
+            raw = list(inner_points_func(ep, ymin, ymax))
+            kept = [p for p in raw if ymin < p < ymax]
+            flag = ("  <-- all points fall outside [ymin, ymax]; "
+                     "ridge is off the bin's Eq range at this Ep"
+                     if not kept else "")
+            print(f"  Ep={ep:12.5f}: raw={[round(p, 4) for p in raw]}  "
+                  f"kept={[round(p, 4) for p in kept]}{flag}")
+            breakpoints_probed.append((ep, raw, kept))
+    else:
+        print("no inner_points_func given -- skipping breakpointed quad")
+
+    # Brute-force reference: fixed grid, Simpson in both directions.
+    # Independent of quad's adaptive sampling entirely, so it's the
+    # sanity check of last resort -- but only trustworthy if n_grid
+    # resolves the PDF's narrowest feature inside the bin.
+    ep_grid = np.linspace(xmin, xmax, n_grid)
+    eq_grid = np.linspace(ymin, ymax, n_grid)
+    Ep_g, Eq_g = np.meshgrid(ep_grid, eq_grid, indexing="ij")
+    vals = np.asarray(pdf_func(Ep_g.ravel(), Eq_g.ravel())).reshape(Ep_g.shape)
+    grid_ref = simpson(simpson(vals, x=eq_grid, axis=1), x=ep_grid)
+    print(f"\nbrute-force grid reference ({n_grid}x{n_grid} Simpson) = {grid_ref:.6g}")
+    print("(raise n_grid if this looks suspicious too -- it must resolve")
+    print(" the narrowest feature of the PDF to be trustworthy)")
+
+    return dict(naive=naive, naive_err=naive_err, fixed=fixed, fixed_err=fixed_err,
+                grid_ref=grid_ref, breakpoints=breakpoints_probed)
 
 
 # ---------------------------------------------------------------------------

--- a/test/python/debug_bin_example.py
+++ b/test/python/debug_bin_example.py
@@ -1,0 +1,52 @@
+"""
+Example: inspect the integration of a single bin in isolation.
+
+Use this when expected_counts_from_pdf reports a ~0 (or suspiciously
+small) expected count for some bin and you need to see why -- run
+chisquare_harness.debug_bin on just that bin instead of the full
+n_bins loop. See debug_bin's docstring for what each of the three
+reported numbers means.
+
+Edit BIN and PARAMS below to match the case you're debugging, then run:
+    LD_LIBRARY_PATH=lib python test/python/debug_bin_example.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "python"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from band_breakpoints import make_ridge_breakpoints
+from ppqfort_pdf import make_ppqg_pdf
+from chisquare_harness import debug_bin
+
+# Same ER/PpqG parameters as test_chisquare_er_simulator.py.
+PARAMS = dict(
+    F0  = 0.122,
+    s   = 0.0,
+    eps = 3.0e-3,
+    V   = 3.0,
+    p0  = 0.06421907,
+    p10 = 0.48998486,
+    q0  = 0.23718488,
+    q10 = 0.27093151,
+)
+
+# The bin reported as ~0: (Ep_min, Ep_max, Eq_min, Eq_max).
+BIN = (64.17183111582968, 66.41909324688707, 33.49076000562251, 184.4618870920465)
+
+# n_workers here only threads the PDF's internal batched grid evaluation
+# (debug_bin's brute-force reference calls it with tens of thousands of
+# points at once); the quad-driven calls are all single points and are
+# unaffected, so this doesn't change what debug_bin demonstrates.
+pdf_fort = make_ppqg_pdf(**PARAMS, n_workers=os.cpu_count())
+ridge_breakpoints = make_ridge_breakpoints(
+    "ER", eps=PARAMS["eps"], V=PARAMS["V"],
+    p0=PARAMS["p0"], p10=PARAMS["p10"],
+    q0=PARAMS["q0"], q10=PARAMS["q10"],
+)
+
+result = debug_bin(pdf_fort, BIN, ridge_breakpoints)


### PR DESCRIPTION
Add chisquare_harness.debug_bin to isolate one bin's PDF integration and compare naive quad, breakpoint-assisted quad, and a brute-force grid reference, so a near-zero expected count can be told apart from a genuine quadrature miss vs a bin that's legitimately mostly off the band. debug_bin_example.py is a ready-to-edit driver; README documents how to read the three numbers.